### PR TITLE
fix: replace deprecated `crypto.pseudoRandomBytes` with `crypto.randomBytes`

### DIFF
--- a/src/TLS/AEADCipher.ts
+++ b/src/TLS/AEADCipher.ts
@@ -103,7 +103,7 @@ export function createCipher(
 
 		// find the right encryption params
 		const salt = (connEnd === "server") ? keyMaterial.server_write_IV : keyMaterial.client_write_IV;
-		const nonce_explicit = crypto.pseudoRandomBytes(cipherParams.recordIvLength);
+		const nonce_explicit = crypto.randomBytes(cipherParams.recordIvLength);
 		// alternatively:
 		// const nonce_explicit = Buffer.concat([
 		// 	BitConverter.numberToBuffer(packet.epoch, 16),

--- a/src/TLS/BlockCipher.ts
+++ b/src/TLS/BlockCipher.ts
@@ -68,7 +68,7 @@ export function createCipher(
 		const padding = Buffer.alloc(padLength + 1, /*fill=*/padLength); // one byte is the actual length of the padding array
 
 		// find the right encryption params
-		const record_iv = crypto.pseudoRandomBytes(cipherParams.recordIvLength);
+		const record_iv = crypto.randomBytes(cipherParams.recordIvLength);
 		const cipher_key = (connEnd === "server") ? keyMaterial.server_write_key : keyMaterial.client_write_key;
 		const cipher = crypto.createCipheriv(algorithm, cipher_key, record_iv);
 		cipher.setAutoPadding(false);


### PR DESCRIPTION
## Summary

- Replace `crypto.pseudoRandomBytes` with `crypto.randomBytes` in `AEADCipher.ts` and `BlockCipher.ts`
- `pseudoRandomBytes` was removed in Node.js 23 — it was a deprecated alias for `randomBytes` (functionally identical)

Fixes #466

## Test plan

- [x] Verified `crypto.randomBytes` is the documented replacement
- [ ] DTLS connection establishment works on Node.js 23+