### PR TITLE
Add ServerKeyExchange to HandshakeMessages

### DIFF
--- a/src/DTLS/Handshake.ts
+++ b/src/DTLS/Handshake.ts
@@ -454,5 +454,6 @@ HandshakeMessages[HandshakeType.hello_request] = HelloRequest;
 HandshakeMessages[HandshakeType.client_hello] = ClientHello;
 HandshakeMessages[HandshakeType.server_hello] = ServerHello;
 HandshakeMessages[HandshakeType.hello_verify_request] = HelloVerifyRequest;
+HandshakeMessages[HandshakeType.server_key_exchange] = ServerKeyExchange;
 HandshakeMessages[HandshakeType.server_hello_done] = ServerHelloDone;
 HandshakeMessages[HandshakeType.finished] = Finished;


### PR DESCRIPTION
Class and handler code for server_key_exchange messages were already in the code, but the server_key_exchange handshake message was not registered in the dispatch map, causing a crash when the server used that message (for example when sending the PSK hint). Just registering it and everything is working fine.